### PR TITLE
Improve ACM Cert Fetching

### DIFF
--- a/src/aws/acm.coffee
+++ b/src/aws/acm.coffee
@@ -1,25 +1,42 @@
 {async, collect, where, empty} = require "fairmont"
 
 module.exports = async (config) ->
-  # TODO: Make the cert lookup more robust.  Consider how to handle multiple
-  # region cert placement.
+  # TODO: Consider how to handle multiple region cert placement.
   {acm} = yield require("./index")("us-east-1")
   {root, regularlyQualify} = do require "./url"
 
-  fetch = async (name) ->
-    wild = (name) -> regularlyQualify "*." + root name
+  wild = (name) -> regularlyQualify "*." + root name
+  apex = (name) -> regularlyQualify root name
 
+  getCertList = async ->
+    data = yield acm.listCertificates CertificateStatuses: [ "ISSUED" ]
+    data.CertificateSummaryList
+
+  # Look for certs that contain wildcard permissions
+  match = async (name, list) ->
+    certs = collect where {DomainName: wild name}, list
+    return certs[0].CertificateArn if !empty certs # Found what we need.
+
+    # No primary wildcard cert.  Look for apex.
+    certs = collect where {DomainName: apex name}, list
+    for cert in certs
+      data = yield acm.describeCertificate {CertificateArn: cert.CertificateArn}
+      alternates = data.Certificate.SubjectAlternativeNames
+      return cert.CertificateArn if wild(name) in alternates
+
+    false # Failed to find wildcard cert among alternate names.
+
+  fetch = async (name) ->
     try
-      data = yield acm.listCertificates CertificateStatuses: [ "ISSUED" ]
-      cert = collect where {DomainName: wild name}, data.CertificateSummaryList
+      arn = yield match name, yield getCertList()
     catch e
       console.error "Unexpected response while searching SSL certs.", e
       throw new Error()
 
-    if empty cert
+    if !arn
       console.error "You do not have an active certificate for", wild name
       throw new Error()
     else
-      cert[0].CertificateArn
+      arn
 
   {fetch}


### PR DESCRIPTION
I've made SSL certificate fetching more robust.  Still looks for wildcard certs, but allows that to be a secondary domain if the primary domain is the apex domain.  This was tested by the successful deployment of [Kitevite's API](https://api.kitevite.com/)