### PR TITLE
Have `init` Add Needed npm Modules For You (sky-39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "1.0.0-alpha-02",
+  "version": "1.0.0-alpha-03",
   "description": "Quicky publish severless applications in the cloud",
   "main": "lib/index.js",
   "bin": {
@@ -37,6 +37,7 @@
     "panda-9000": "^2.0.0-alpha-02",
     "panda-serialize": "^0.2.0",
     "panda-template": "0.3.0",
+    "prompt": "^1.0.0",
     "rimraf": "^2.5.4"
   },
   "keywords": [

--- a/src/init.coffee
+++ b/src/init.coffee
@@ -1,14 +1,41 @@
 {join} = require "path"
 {define} = require "panda-9000"
-{async, randomWords, read, write} = require "fairmont"
+{async, randomWords, read, write, shell} = require "fairmont"
 _render = require "panda-template"
 {safe_cp, safe_mkdir} = require "./utils"
+interview = require "./interview"
 
 # This sets up an existing directory to hold a Panda Sky project.
 define "init", async ->
   try
+    # Ask politely to install fairmont and js-yaml
+    # TODO: fold the parts of these that we use in the Lambdas into wrapper
+    #     to be intorduced in beta-02
+    interview.setup()
+    questions = [
+      name: "fairmont"
+      description: "Add fairmont as a dependency to package.json? [Y/n]"
+      default: "Y"
+    ,
+      name: "yaml"
+      description: "Add js-yaml as a dependency to package.json? [Y/n]"
+      default: "Y"
+    ]
+
+    console.log "Press ^C at any time to quit."
+    answers = yield interview.ask questions
+
+    if answers.fairmont || answers.yaml
+      console.log "\n Adding module(s). One moment..."
+      yield shell "npm install fairmont --save" if answers.fairmont
+      yield shell "npm install js-yaml --save" if answers.yaml
+
+
+
     config =
       projectID: yield randomWords 6
+
+    # Drop in the file stubs.
     src = (file) -> join( __dirname, "../init/#{file}")
     target = (file) -> join process.cwd(), file
 

--- a/src/interview.coffee
+++ b/src/interview.coffee
@@ -1,0 +1,25 @@
+prompt = require "prompt"
+
+module.exports = 
+
+  # Initialize the interviewer.  Remove the default settings, start `prompt`
+  setup: ->
+    prompt.message = ""
+    prompt.delimiter = ""
+    prompt.start()
+
+  # Execute the interview.  Wrap the menthod in a promise to use ES6 style.
+  ask: (questions) ->
+    new Promise (resolve, reject) ->
+      prompt.get questions, (error, answers) ->
+        if error?
+          reject error
+        else
+          # Map boolean-esque answers onto "true" and "false" values.
+          for k of answers
+            if answers[k] in ["yes", "Yes", "YES", "y", "Y", "true", "True"]
+              answers[k] = true
+            if answers[k] in ["no", "No", "NO", "n", "N", "false", "False"]
+              answers[k] = false
+
+          resolve answers

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -6,9 +6,12 @@ module.exports =
 
   # Make a directory at the specified path if it doesn't already exist.
   safe_mkdir: async (path, mode) ->
-    unless yield exists path
-      mode ||= "0777"
-      yield mkdir mode, path
+    if yield exists path
+      console.log "Warning: #{path} exists. Skipping."
+      return
+
+    mode ||= "0777"
+    yield mkdir mode, path
 
   # Copy a file to the target, but only if it doesn't already exist.
   safe_cp: async (original, target) ->


### PR DESCRIPTION
I've added an interviewer to the `sky init` command that politely asks to add `fairmont` and `js-yaml` to your project to get the barebones Panda Sky deployment running.

I see that #39 says to include`panda-sky` in your project, but we haven't written the wrapper function to help author lambdas yet because that's a beta-02 feature.  Is this acceptable until then?