### PR TITLE
bug in npm watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "prepublish": "coffee -o lib/ -c src/",
-    "watch": "coffee -o lib/ -cw src/*.coffee src/**/*.coffee",
+    "watch": "coffee -o lib/ -cw src/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Use of ** in the glob was causing coffee to compile files from all levels of nesting to a flat space in a directory.  Amusingly, this also caused corrupted files, rather than simply replacements.  Symptom was a Javascript syntax error.