### PR TITLE
63 request mapping template

### DIFF
--- a/mixins/api.yaml
+++ b/mixins/api.yaml
@@ -148,7 +148,7 @@ Method:
             - "/invocations"
       {{#if ../parameters}}
       RequestTemplates:
-        "application/json": |-
+        "application/json": >
           {
             "url": {
               "path": {

--- a/mixins/api.yaml
+++ b/mixins/api.yaml
@@ -148,8 +148,32 @@ Method:
             - "/invocations"
       {{#if ../parameters}}
       RequestTemplates:
-        "application/json": >
-          { {{#join ", " ../parameters}}"{{name}}": "$input.params('{{name}}')"{{/join}} }
+        "application/json": |-
+          {
+            "url": {
+              "path": {
+                #foreach($param in $input.params().path.keySet())
+                "$param": "$util.escapeJavaScript($input.params().path.get($param))"
+                #if($foreach.hasNext),#end
+                #end
+              },
+              "query": {
+                #foreach($param in $input.params().querystring.keySet())
+                "$param": "$util.escapeJavaScript($input.params().querystring.get($param))"
+                #if($foreach.hasNext),#end
+                #end
+              }
+            },
+            "method": "$context.httpMethod",
+            "headers": {
+              #foreach($param in $input.params().header.keySet())
+              "$param": "$util.escapeJavaScript($input.params().header.get($param))"
+              #if($foreach.hasNext),#end
+              #end
+            },
+            "content" : $input.json('$')
+          }
+
       {{/if}}
 
 

--- a/mixins/api.yaml
+++ b/mixins/api.yaml
@@ -146,7 +146,6 @@ Method:
             LambdaHandler",
             "Arn"]}
             - "/invocations"
-      {{#if ../parameters}}
       RequestTemplates:
         "application/json": >
           {
@@ -174,7 +173,6 @@ Method:
             "content" : $input.json('$')
           }
 
-      {{/if}}
 
 
       IntegrationResponses:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "1.0.0-beta-08",
+  "version": "1.0.0-beta-09",
   "description": "Quicky publish severless applications in the cloud",
   "main": "lib/sky-helpers/index.js",
   "bin": {

--- a/schema/request-representation.yaml
+++ b/schema/request-representation.yaml
@@ -1,0 +1,58 @@
+$schema: http://json-schema.org/draft-04/schema
+title: Panda Request Representation
+description: >
+  A standard format for expressing all of the dimensions of an HTTP request in
+  a single, nested object.  Usable in AWS Lambda handler functions, or in any
+  simiar function-based approach.
+
+example:
+
+  url:
+    path:
+      account: wyrdspirits
+    query:
+      campaignID: a93f15c7081
+  method: PATCH
+  headers:
+    Authorization: PandaGuard z=asdfi8092,yy=akdflasdidfms,d=4tnookie
+    Content-Type: application/vnd.pandamarket.campaign_update+json
+    Accept: application/vnd.pandamarket.campaign_view+json
+  content: # May also be a Buffer or other non-Object
+    startTime: 1094057845748
+    spend: 40000
+    proof: 107
+
+type: object
+properties:
+  required:
+    - url
+    - method
+    - headers
+    # I'm not sure yet if the VTL will let us put in a null value for requests
+    # where there is no message body.
+    # - content
+  url:
+    description: >
+      Contains the parameters derived from the URL path and querystring
+      as separate dictionaries.
+    type: object
+    properties:
+      path:
+        type: object
+        additionalProperties:
+          type: string
+      query:
+        type: object
+        additionalProperties:
+          type: string
+  method:
+    description: >
+      The name of the HTTP method.
+    type: string
+  headers:
+    description: >
+      A dictionary of the HTTP request headers.
+    type: object
+  content:
+    description: >
+      The parsed content of the HTTP message body.

--- a/schema/request-representation.yaml
+++ b/schema/request-representation.yaml
@@ -11,12 +11,12 @@ example:
     path:
       account: wyrdspirits
     query:
-      campaignID: a93f15c7081
+      product: a93f15c7081
   method: PATCH
   headers:
     Authorization: PandaGuard z=asdfi8092,yy=akdflasdidfms,d=4tnookie
-    Content-Type: application/vnd.pandamarket.campaign_update+json
-    Accept: application/vnd.pandamarket.campaign_view+json
+    Content-Type: application/vnd.pandamarket.product_update+json
+    Accept: application/vnd.pandamarket.product_view+json
   content: # May also be a Buffer or other non-Object
     startTime: 1094057845748
     spend: 40000

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -5,6 +5,8 @@ program = require "commander"
 require "./index"
 {run} = require "panda-9000"
 
+render = require "./render"
+
 call ->
 
   {version} = JSON.parse yield read join __dirname, "..", "package.json"
@@ -31,6 +33,11 @@ call ->
     .command('delete [env]')
     .description('deploy API, Lambdas to AWS infrastructure')
     .action((env)-> run "delete", [env])
+
+  program
+    .command('render')
+    .description('render the CloudFormation template to STDOUT')
+    .action (env) -> render(env)
 
   program
     .command('*')

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -35,7 +35,7 @@ call ->
     .action((env)-> run "delete", [env])
 
   program
-    .command('render')
+    .command('render [env]')
     .description('render the CloudFormation template to STDOUT')
     .action (env) -> render(env)
 

--- a/src/configuration/preprocessors/api/mapping-template.coffee
+++ b/src/configuration/preprocessors/api/mapping-template.coffee
@@ -1,0 +1,27 @@
+module.exports = '''
+{
+  "url": {
+    "path": {
+      #foreach($param in $input.params().path.keySet())
+      "$param": "$util.escapeJavaScript($input.params().path.get($param))"
+      #if($foreach.hasNext),#end
+      #end
+    },
+    "query": {
+      #foreach($param in $input.params().querystring.keySet())
+      "$param": "$util.escapeJavaScript($input.params().querystring.get($param))"
+      #if($foreach.hasNext),#end
+      #end
+    }
+  },
+  "method": "$context.httpMethod",
+  "headers": {
+    #foreach($param in $input.params().header.keySet())
+    "$param": "$util.escapeJavaScript($input.params().header.get($param))"
+    #if($foreach.hasNext),#end
+    #end
+  },
+  "content" : $input.json('$')
+}
+'''
+

--- a/src/delete.coffee
+++ b/src/delete.coffee
@@ -1,5 +1,6 @@
 {define} = require "panda-9000"
 {async, first, sleep} = require "fairmont"
+{bellChar} = require "./utils"
 
 define "delete", async (env) ->
   try
@@ -14,4 +15,4 @@ define "delete", async (env) ->
     console.log "Done"
   catch e
     console.log e.stack
-  console.log '\u0007'
+  console.log bellChar

--- a/src/publish.coffee
+++ b/src/publish.coffee
@@ -1,5 +1,6 @@
 {define} = require "panda-9000"
 {async, first, sleep} = require "fairmont"
+{bellChar} = require "./utils"
 
 define "publish", async (env) ->
   try
@@ -14,4 +15,4 @@ define "publish", async (env) ->
     console.log "Done"
   catch e
     console.error e.stack
-  console.log '\u0007'
+  console.log bellChar

--- a/src/render.coffee
+++ b/src/render.coffee
@@ -1,0 +1,20 @@
+{yaml, json} = require "panda-serialize"
+{async, first, sleep} = require "fairmont"
+
+module.exports = async (env) ->
+  try
+    config = yield require("./configuration/compile")(env)
+    console.log yaml json config.aws.cfoTemplate
+    #stack = yield require("./aws/cloudformation")(env, config)
+
+    #id = yield stack.publish()
+    #if id
+      #console.log "Waiting for deployment to be ready."
+      #yield stack.publishWait id
+    #yield stack.postPublish()
+    #console.log "Done"
+  catch e
+    console.error e.stack
+
+  console.log '\u0007'
+

--- a/src/render.coffee
+++ b/src/render.coffee
@@ -1,5 +1,6 @@
 {yaml, json} = require "panda-serialize"
 {async, first, sleep} = require "fairmont"
+{bellChar} = require "./utils"
 
 module.exports = async (env) ->
   try
@@ -16,5 +17,5 @@ module.exports = async (env) ->
   catch e
     console.error e.stack
 
-  console.log '\u0007'
+  console.log bellChar
 

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -20,3 +20,5 @@ module.exports =
       return
 
     yield shell "cp #{original} #{target}"
+
+  bellChar: '\u0007'


### PR DESCRIPTION
This branch sets an API Gateway Request [Mapping Template for all resource-methods](https://github.com/pandastrike/panda-sky/blob/63-request-mapping-template/mixins/api.yaml#L149-L174) other than the discovery ones.

The Mapping Template provides Lambda handlers a standardized format for representing HTTP requests (Panda Request Representation).

I also added a [JSON Schema for the PRR](https://github.com/pandastrike/panda-sky/blob/63-request-mapping-template/schema/request-representation.yaml), with an embedded example.

This PR breaks all existing Sky apps.