### PR TITLE
Usability Upgrades - Fast Publishing and File Watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "panda-template": "0.3.0",
     "prompt": "^1.0.0",
     "rimraf": "^2.5.4",
-    "standard-error": "^1.1.0"
+    "standard-error": "^1.1.0",
+    "watch": "^1.0.2"
   },
   "keywords": [
     "Serverless",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "1.0.0-beta-12",
+  "version": "1.0.0-beta-13",
   "description": "Quicky publish severless applications in the cloud",
   "main": "lib/sky-helpers/index.js",
   "bin": {

--- a/src/aws/index.coffee
+++ b/src/aws/index.coffee
@@ -44,7 +44,8 @@ module.exports = async (region) ->
   gw = liftModule new AWS.APIGateway()
   cfo = liftModule new AWS.CloudFormation()
   cfr = liftModule new AWS.CloudFront()
+  lambda = liftModule new AWS.Lambda()
   route53 = liftModule new AWS.Route53()
   s3 = liftModule new AWS.S3()
 
-  {acm, gw, cfo, cfr, route53, s3}
+  {acm, gw, cfo, cfr, lambda, route53, s3}

--- a/src/aws/lambda.coffee
+++ b/src/aws/lambda.coffee
@@ -1,0 +1,13 @@
+{async} = require "fairmont"
+
+module.exports = async (config) ->
+  {lambda} = yield require("./index")(config.aws.region)
+
+  update = async (name, bucket, key) ->
+    yield lambda.updateFunctionCode
+      FunctionName: name
+      Publish: true
+      S3Bucket: bucket
+      S3Key: key
+
+  {update}

--- a/src/build-update.coffee
+++ b/src/build-update.coffee
@@ -1,0 +1,35 @@
+{writeFileSync} = require "fs"
+path = require "path"
+{go, tee, pull, values, async, lift, shell, exists, sleep} = require "fairmont"
+{define, write} = require "panda-9000"
+rmrf = lift require "rimraf"
+
+{render} = Asset = require "./asset"
+{safe_mkdir} = require "./utils"
+
+define "build-update", ["survey"], async (cmd) ->
+  try
+    source = "src"
+    target = "lib"
+    manifest = "package.json"
+
+    # Dump the processed assets from "src" into an intermidate directory, lib.
+    yield go [
+      Asset.iterator()
+      tee async (formats) ->
+        yield go [
+          values formats
+          tee render
+          pull
+          tee write target
+        ]
+    ]
+
+    try
+      yield sleep 100  # TODO: This is hacky, but the write isn't complete when we get here sometimes.
+      yield shell cmd
+    catch e
+      console.error e
+
+  catch e
+    console.error e.stack

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -3,9 +3,8 @@ program = require "commander"
 {call, read, collect, project, empty} = require "fairmont"
 
 require "./index"
+watch = require "./watch"
 {run} = require "panda-9000"
-
-render = require "./render"
 
 call ->
 
@@ -37,7 +36,17 @@ call ->
   program
     .command('render [env]')
     .description('render the CloudFormation template to STDOUT')
-    .action (env) -> render(env)
+    .action((env)-> run "render", [env])
+
+  program
+    .command('update [env]')
+    .description('Update *only* the Lambda code for an environment')
+    .action((env)-> run "update", [env])
+
+  program
+    .command('watch [env]')
+    .description('Watch for file changes and update *only* the Lambda code for an environment')
+    .action((env)-> watch env)
 
   program
     .command('*')

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -44,9 +44,9 @@ call ->
     .action((env)-> run "update", [env])
 
   program
-    .command('watch [env]')
+    .command('watch')
     .description('Watch for file changes and update *only* the Lambda code for an environment')
-    .action((env)-> watch env)
+    .action(-> watch())
 
   program
     .command('*')

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,6 +2,9 @@ require "./build"
 require "./delete"
 require "./init"
 require "./publish"
+require "./render"
 require "./survey"
+require "./update"
+require "./watch"
 
 module.exports = (AWS) -> require("./sky-helpers")(AWS)

--- a/src/render.coffee
+++ b/src/render.coffee
@@ -1,21 +1,13 @@
+{define} = require "panda-9000"
 {yaml, json} = require "panda-serialize"
-{async, first, sleep} = require "fairmont"
+{async} = require "fairmont"
 {bellChar} = require "./utils"
 
-module.exports = async (env) ->
+define "render", async (env) ->
   try
     config = yield require("./configuration/compile")(env)
     console.log yaml json config.aws.cfoTemplate
-    #stack = yield require("./aws/cloudformation")(env, config)
-
-    #id = yield stack.publish()
-    #if id
-      #console.log "Waiting for deployment to be ready."
-      #yield stack.publishWait id
-    #yield stack.postPublish()
-    #console.log "Done"
   catch e
     console.error e.stack
 
   console.log bellChar
-

--- a/src/update.coffee
+++ b/src/update.coffee
@@ -1,0 +1,27 @@
+{join} = require "path"
+{define} = require "panda-9000"
+{async, read, toLower} = require "fairmont"
+{yaml} = require "panda-serialize"
+{bellChar} = require "./utils"
+
+
+define "update", async (env) ->
+  try
+    config = yield require("./configuration/compile")(env)
+    {lambdaUpdate} = yield require("./aws/app-root")(env, config)
+    api = yaml yield read join process.cwd(), "api.yaml"
+    fullName = "#{config.name}-#{env}"
+
+    # Get names of all Lambdas
+    lambdas = []
+    for r, resource of api.resources
+      for a, action of resource.actions
+         lambdas.push "#{fullName}-#{r}-#{toLower action.method}"
+
+
+    yield lambdaUpdate lambdas, "#{env}-#{config.projectID}"
+
+
+  catch e
+    console.error e.stack
+  console.log bellChar

--- a/src/watch-helpers.coffee
+++ b/src/watch-helpers.coffee
@@ -1,0 +1,63 @@
+{join} = require "path"
+{async, shell, exists, stat, isDirectory} = require "fairmont"
+
+{run} = require "panda-9000"
+
+# Tasks
+require "./build"
+require "./build-update"
+
+module.exports = do async ->
+  archive_path = join process.cwd(), "deploy/package.zip"
+  node_path = join process.cwd(), "node_modules"
+  relativeNodePath = (p) -> p.split(process.cwd())[1]
+  relativeBufferPath = (p) -> p.split(join(process.cwd(), "lib"))[1]
+  relativeSrcPath = (p) -> p.split(join(process.cwd(), "src"))[1]
+
+  if !(yield exists archive_path)
+    console.log "============================================================"
+    console.log "Did not detect deploy archive. "
+    console.log "One moment while it is constructed. (Wait for Task 'build' to complete)"
+    console.log "============================================================\n"
+    run "build"
+
+  src = do ->
+    # TODO: Fix this to handle .coffee and other extensions better.
+    convert = (f) -> f.replace /\.coffee$/, ".js"
+
+    created: (f) ->
+      console.log "//   Detected file creation - Adding #{f}\n"
+      f = convert f
+      run "build-update", ["zip -u #{archive_path} lib#{relativeSrcPath f}"]
+    changed: (f) ->
+      console.log "//   Detected file change - Updating #{f}\n"
+      f = convert f
+      run "build-update", ["zip -u #{archive_path} lib#{relativeSrcPath f}"]
+    removed: (f) ->
+      console.log "//   Detected file deletion - Removing #{f}\n"
+      f = convert f
+      shell "zip -d #{archive_path} lib#{relativeSrcPath f}"
+      .then ->
+        shell "rm -r #{join process.cwd(), "lib", relativeSrcPath(f)}"
+
+  node = do ->
+    _update = (f) ->
+      console.log "//   Detected \"node_modules\" file change - Updating #{f}\n"
+      isDirectory f
+      .then (isDir) ->
+        if isDir
+          shell "cp -R #{f} lib#{relativeNodePath f}/ && zip -ur #{archive_path} lib#{relativeNodePath f}/"
+        else
+          shell "cp #{f} lib#{relativeNodePath f} && zip -u #{archive_path} lib#{relativeNodePath f}"
+
+    created: (f) -> _update f
+    changed: (f) -> _update f
+    removed: (f) ->
+      console.log "//   Detected \"node_modules\" file deletion #{f}\n"
+      shell "zip -d #{archive_path} \"lib#{relativeNodePath f}/\*\""
+      .then ->
+        shell "rm -r #{join process.cwd(), "lib", relativeNodePath(f)}"
+        .catch (e) -> # Swallow deletion errors
+      .catch (e) -> console.log "File already deleted"
+
+  {src, node}

--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -1,0 +1,34 @@
+{join} = require "path"
+http = require "http"
+{async} = require "fairmont"
+{yaml} = require "panda-serialize"
+{bellChar} = require "./utils"
+
+watch = require "watch"
+
+module.exports = async (env) ->
+  try
+    # the default options
+    opts =
+      ignoreDotFiles: false       # When true this option means that when the file tree is walked it will ignore files that being with "."
+      interval: 1                 # Specifies the interval duration in seconds, the time period between polling for file changes.
+      ignoreUnreadableDir: false  # When true, this options means that when a file can't be read, this file is silently skipped.
+      ignoreNotPermitted: false   # When true, this options means that when a file can't be read due to permission issues, this file is silently skipped.
+
+    # Watch 'src/' and 'node_modules/'
+    {src, node, buffer} = yield require "./watch-helpers"
+
+    watch.createMonitor (join process.cwd(), "src"), opts, (monitor) ->
+      monitor.on "created", (f, stat) -> src.created f
+      monitor.on "changed", (f, curr, prev) -> src.changed f
+      monitor.on "removed", (f, stat) -> src.removed f
+
+    watch.createMonitor (join process.cwd(), "node_modules"), opts, (monitor) ->
+      monitor.on "created", (f, stat) -> node.created f
+      monitor.on "changed", (f, curr, prev) -> node.changed f
+      monitor.on "removed", (f, stat) -> node.removed f
+
+    console.log "Watching source code. Stop with Ctrl+C"
+  catch e
+    console.error e.stack
+  console.log bellChar

--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -6,7 +6,7 @@ http = require "http"
 
 watch = require "watch"
 
-module.exports = async (env) ->
+module.exports = async ->
   try
     # the default options
     opts =


### PR DESCRIPTION
1. Made render a p9k procedure
2. Implemented Lamba-only Sky update that can be invoked with `sky update <env>`  It will publish the lambda only of whatever is in the code archive. 
3. Implemented alpha version of file watcher to speed build.  Invoked with `sky watch`.  It will watch your `src/` and `node_module` directories and update the package.zip used to hold your Lambdas in the Cloud.