### PR TITLE
Make "Sky Render" a P9K Task 

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -5,8 +5,6 @@ program = require "commander"
 require "./index"
 {run} = require "panda-9000"
 
-render = require "./render"
-
 call ->
 
   {version} = JSON.parse yield read join __dirname, "..", "package.json"
@@ -37,7 +35,7 @@ call ->
   program
     .command('render [env]')
     .description('render the CloudFormation template to STDOUT')
-    .action (env) -> render(env)
+    .action((env)-> run "render", [env])
 
   program
     .command('*')

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,6 +2,7 @@ require "./build"
 require "./delete"
 require "./init"
 require "./publish"
+require "./render"
 require "./survey"
 
 module.exports = (AWS) -> require("./sky-helpers")(AWS)

--- a/src/render.coffee
+++ b/src/render.coffee
@@ -1,21 +1,13 @@
 {yaml, json} = require "panda-serialize"
 {async, first, sleep} = require "fairmont"
 {bellChar} = require "./utils"
+{define} = require "panda-9000"
 
-module.exports = async (env) ->
+define "render", async (env) ->
   try
     config = yield require("./configuration/compile")(env)
     console.log yaml json config.aws.cfoTemplate
-    #stack = yield require("./aws/cloudformation")(env, config)
-
-    #id = yield stack.publish()
-    #if id
-      #console.log "Waiting for deployment to be ready."
-      #yield stack.publishWait id
-    #yield stack.postPublish()
-    #console.log "Done"
   catch e
     console.error e.stack
 
   console.log bellChar
-


### PR DESCRIPTION
Altered the "render" command to make it a p9k task.  This brings it in line with the other Sky CLI commands.

From @automatthew: 
> Why should any of these be p9k procedures? I found it very difficult to trace what was happening in panda-sky, which is why I specifically made the render command use a simple, easy-to-find function.
>
> What am I missing?

From @freeformflow
> @dyoder, I agree with Matthew that the p9k routines can be a little awkward to use sometimes. I know that you bulilt the first ones to do filesystem tasks with Haiku, like the asset pipeline transcompilation of CoffeeScript to JS. Does it make sense to continue using p9k in Panda Sky, however?