### PR TITLE
Usability Upgrade - File Watcher to Amend Lambda Archive with "sky watch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "panda-template": "0.3.0",
     "prompt": "^1.0.0",
     "rimraf": "^2.5.4",
-    "standard-error": "^1.1.0"
+    "standard-error": "^1.1.0",
+    "watch": "^1.0.2"
   },
   "keywords": [
     "Serverless",

--- a/src/build-update.coffee
+++ b/src/build-update.coffee
@@ -1,0 +1,35 @@
+{writeFileSync} = require "fs"
+path = require "path"
+{go, tee, pull, values, async, lift, shell, exists, sleep} = require "fairmont"
+{define, write} = require "panda-9000"
+rmrf = lift require "rimraf"
+
+{render} = Asset = require "./asset"
+{safe_mkdir} = require "./utils"
+
+define "build-update", ["survey"], async (cmd) ->
+  try
+    source = "src"
+    target = "lib"
+    manifest = "package.json"
+
+    # Dump the processed assets from "src" into an intermidate directory, lib.
+    yield go [
+      Asset.iterator()
+      tee async (formats) ->
+        yield go [
+          values formats
+          tee render
+          pull
+          tee write target
+        ]
+    ]
+
+    try
+      yield sleep 100  # TODO: This is hacky, but the write isn't complete when we get here sometimes.
+      yield shell cmd
+    catch e
+      console.error e
+
+  catch e
+    console.error e.stack

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -5,6 +5,7 @@ program = require "commander"
 require "./index"
 {run} = require "panda-9000"
 
+watch = require "./watch"
 render = require "./render"
 
 call ->
@@ -38,6 +39,12 @@ call ->
     .command('render [env]')
     .description('render the CloudFormation template to STDOUT')
     .action (env) -> render(env)
+
+  program
+  .command('watch')
+  .description('Watch for file changes and update *only* the Lambda code for an environment')
+  .action((env)-> watch())
+
 
   program
     .command('*')

--- a/src/watch-helpers.coffee
+++ b/src/watch-helpers.coffee
@@ -1,0 +1,63 @@
+{join} = require "path"
+{async, shell, exists, stat, isDirectory} = require "fairmont"
+
+{run} = require "panda-9000"
+
+# Tasks
+require "./build"
+require "./build-update"
+
+module.exports = do async ->
+  archive_path = join process.cwd(), "deploy/package.zip"
+  node_path = join process.cwd(), "node_modules"
+  relativeNodePath = (p) -> p.split(process.cwd())[1]
+  relativeBufferPath = (p) -> p.split(join(process.cwd(), "lib"))[1]
+  relativeSrcPath = (p) -> p.split(join(process.cwd(), "src"))[1]
+
+  if !(yield exists archive_path)
+    console.log "============================================================"
+    console.log "Did not detect deploy archive. "
+    console.log "One moment while it is constructed. (Wait for Task 'build' to complete)"
+    console.log "============================================================\n"
+    run "build"
+
+  src = do ->
+    # TODO: Fix this to handle .coffee and other extensions better.
+    convert = (f) -> f.replace /\.coffee$/, ".js"
+
+    created: (f) ->
+      console.log "//   Detected file creation - Adding #{f}\n"
+      f = convert f
+      run "build-update", ["zip -u #{archive_path} lib#{relativeSrcPath f}"]
+    changed: (f) ->
+      console.log "//   Detected file change - Updating #{f}\n"
+      f = convert f
+      run "build-update", ["zip -u #{archive_path} lib#{relativeSrcPath f}"]
+    removed: (f) ->
+      console.log "//   Detected file deletion - Removing #{f}\n"
+      f = convert f
+      shell "zip -d #{archive_path} lib#{relativeSrcPath f}"
+      .then ->
+        shell "rm -r #{join process.cwd(), "lib", relativeSrcPath(f)}"
+
+  node = do ->
+    _update = (f) ->
+      console.log "//   Detected \"node_modules\" file change - Updating #{f}\n"
+      isDirectory f
+      .then (isDir) ->
+        if isDir
+          shell "cp -R #{f} lib#{relativeNodePath f}/ && zip -ur #{archive_path} lib#{relativeNodePath f}/"
+        else
+          shell "cp #{f} lib#{relativeNodePath f} && zip -u #{archive_path} lib#{relativeNodePath f}"
+
+    created: (f) -> _update f
+    changed: (f) -> _update f
+    removed: (f) ->
+      console.log "//   Detected \"node_modules\" file deletion #{f}\n"
+      shell "zip -d #{archive_path} \"lib#{relativeNodePath f}/\*\""
+      .then ->
+        shell "rm -r #{join process.cwd(), "lib", relativeNodePath(f)}"
+        .catch (e) -> # Swallow deletion errors
+      .catch (e) -> console.log "File already deleted"
+
+  {src, node}

--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -1,0 +1,34 @@
+{join} = require "path"
+http = require "http"
+{async} = require "fairmont"
+{yaml} = require "panda-serialize"
+{bellChar} = require "./utils"
+
+watch = require "watch"
+
+module.exports = async (env) ->
+  try
+    # the default options
+    opts =
+      ignoreDotFiles: false       # When true this option means that when the file tree is walked it will ignore files that being with "."
+      interval: 1                 # Specifies the interval duration in seconds, the time period between polling for file changes.
+      ignoreUnreadableDir: false  # When true, this options means that when a file can't be read, this file is silently skipped.
+      ignoreNotPermitted: false   # When true, this options means that when a file can't be read due to permission issues, this file is silently skipped.
+
+    # Watch 'src/' and 'node_modules/'
+    {src, node, buffer} = yield require "./watch-helpers"
+
+    watch.createMonitor (join process.cwd(), "src"), opts, (monitor) ->
+      monitor.on "created", (f, stat) -> src.created f
+      monitor.on "changed", (f, curr, prev) -> src.changed f
+      monitor.on "removed", (f, stat) -> src.removed f
+
+    watch.createMonitor (join process.cwd(), "node_modules"), opts, (monitor) ->
+      monitor.on "created", (f, stat) -> node.created f
+      monitor.on "changed", (f, curr, prev) -> node.changed f
+      monitor.on "removed", (f, stat) -> node.removed f
+
+    console.log "Watching source code. Stop with Ctrl+C"
+  catch e
+    console.error e.stack
+  console.log bellChar


### PR DESCRIPTION
Added file watcher via the new `watch` command.  Sky will watch the `src/` and `node_modules/` directories and amend the package.json that gets sent up to AWS to run the Lambdas.  

This is meant to be used with the new `update` command in a separate commit.  `watch` allows developers to skip the `build` command as they edit code in a development session, and then issue a fast publish `update` of that code that lets them try the code live in 10 or so seconds.

I would consider this more of an Alpha sub-feature.  What I wrote is effective for small changes, especially edits to existing files.  But this could probably use another pass reactive flows in mind, using the change events as sources and the `go` flow structure.