### PR TITLE
Sky.dispatch helper

### DIFF
--- a/src/sky-helpers/index.coffee
+++ b/src/sky-helpers/index.coffee
@@ -1,7 +1,23 @@
 # These helpers make it easier to do HTTP and AWS things with your project's context.
+#
+
+# Provides the dispatching logic so Sky apps don't need to know how we
+# structure things.
+dispatch = (handlers) ->
+  (request, context, callback) ->
+    handler = handlers[context.functionName]
+    unless typeof handler is 'function'
+      console.error "Failed to execute: " + context.functionName
+      return callback new response.Internal()
+
+    handler request, context
+    .then (result) -> callback null, result
+    .catch (e) -> callback e
+
 
 module.exports = (AWS) ->
   async: require("fairmont").async
   response: require("./responses")
   s3: require("./s3")(AWS)
   method: require "./method"
+  dispatch: dispatch


### PR DESCRIPTION
Rather than writing the lambda-handler dispatch function in each app, we can provide one in Panda Sky that centralizes and encapsulates the logic.

Will be extremely helpful when we start altering the lambda naming conventions.


```coffee
AWS = require "aws-sdk"
Sky = require("panda-sky")(AWS)

Blurb =
  "discovery-get": async (format, context) ->
    work_work_work()

exports.handler = Sky.dispatch Blurb

```
