### PR TITLE
Use CLI from arbitrary git branch

### DIFF
--- a/bin/sky
+++ b/bin/sky
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
 
-require("../lib/cli");
+require("coffeescript").register();
+require("../src/cli");

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require("coffeescript").register();
+module.exports = require("./src/sky-helpers/index");

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "bin",
     "init",
     "lib",
+    "schema",
+    "src",
     "mixins",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -2,22 +2,20 @@
   "name": "panda-sky",
   "version": "1.0.0-beta-17",
   "description": "Quicky publish severless applications in the cloud",
-  "main": "lib/sky-helpers/index.js",
+  "main": "./index.js",
   "bin": {
     "sky": "./bin/sky"
   },
   "files": [
     "bin",
     "init",
-    "lib",
     "schema",
+    "templates",
     "src",
     "mixins",
     "LICENSE"
   ],
   "scripts": {
-    "prepublish": "coffee -o lib/ -c src/",
-    "watch": "coffee -o lib/ -cw src/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -31,6 +29,7 @@
   "dependencies": {
     "auth-header": "^0.3.1",
     "aws-sdk": "^2.3.18",
+    "coffeescript": "^1.12.6",
     "commander": "^2.9.0",
     "fairmont": "^1.1.6",
     "js-yaml": "^3.6.1",


### PR DESCRIPTION
We need to be able to test the `sky` CLI tool from arbitrary branches of panda-sky.  Provisional usage pattern in projects such as blurb9:

- update the package.json with a Git URL to the desired branch of panda-sky
- `npm install`
- `./node_modules/.bin/sky <command>`

This was tricky, because the npm setup for panda-sky involves compiling CoffeeScript to JavaScript, then packaging that.  We have not been committing the .js artefacts to the repo, so the npm install from git does not have any of the necessary code.

My solution should be considered as a temporary measure to support the current flash development needs.  It should technically work for npm publishing, but is probably not what we want for an OSS package.

- add "coffeescript" as an npm dependency for panda-sky
- alter `bin/sky` so that it registers CoffeeScript, then requires `../src/cli`
- change the "main" in `package.json` to be `./index.js`
- add `index.js`, which registers CoffeeScript and requires `src/sky-helpers/index`

With these changes, the desired in-product usage above works.


