### PR TITLE
Workaround for AWS Lambda timeout death

### DIFF
--- a/src/sky-helpers/index.coffee
+++ b/src/sky-helpers/index.coffee
@@ -5,6 +5,7 @@
 # structure things.
 dispatch = (handlers) ->
   (request, context, callback) ->
+    console.log "Dispatching to '#{context.functionName}' handler"
     handler = handlers[context.functionName]
     unless typeof handler is 'function'
       console.error "Failed to execute: " + context.functionName

--- a/templates/method.yaml
+++ b/templates/method.yaml
@@ -120,6 +120,8 @@
       {{/eachProperty}}
   {{#if timeout}}
     Timeout: {{timeout}}
+  {{else}}
+    Timeout: 15
   {{/if}}
     Code:
       S3Bucket: {{handler.bucket}}


### PR DESCRIPTION
Problem:  if a Lambda request handler times out due to slow startup, often subsequent requests will timeout as well, because the Lambda container is still working on the event loop from the first request.

There is a property on the handler `context` object you can set to allow subsequent requests to work, but it's a bit of a hack.

```coffee
context.callbackWaitsForEmptyEventLoop = false
```

> By default, the callback will wait until the Node.js runtime event loop is empty before freezing the process and returning the results to the caller. You can set this property to false to request AWS Lambda to freeze the process soon after the callback is called, even if there are events in the event loop.

In my testing, this does allow subsequent requests to work after a timeout.  The problem is that the event loop is not getting cleared per request, which may have unpredictable consequences.

I believe a better solution would be to make sure that all async work performed in our request handlers is prevented from outlasting the Lambda timeout.  

For example, we can set `config.httpTimeout` for the s3 client as a whole, or for individual services.  We will need some way to coordinate this with the Lambda timeouts.

It's annoying that we have to think about this, but ultimately necessary.