### PR TITLE
Attempt to fix problem deploying to prod.

### DIFF
--- a/src/aws/app-root.coffee
+++ b/src/aws/app-root.coffee
@@ -70,7 +70,7 @@ module.exports = async (env, config) ->
         template
 
       hard = (template) ->
-        retain = ["API", "LambdaRole", "CFRDistro", "DNSRecords"]
+        retain = ["API", "LambdaRole" ]
         R = template.Resources
         delete R[k] for k, v of R when !(k in retain) && !k.match(/^Mixin/)
         template.Resources = R


### PR DESCRIPTION
The "hard" template removes some of the Resources to cause a rebuild.
Retaining CloudFront, however, causes an error because it depends
on the "Deployment" resource.