### PR TITLE
Bug Fix: Allow Graceful Failure of Sky Metadata Update in Domain Deletion

### DIFF
--- a/src/aws/sky/meta.coffee
+++ b/src/aws/sky/meta.coffee
@@ -44,7 +44,11 @@ module.exports = (s) ->
       data = yield fetch()
       data = remove data, name
       data = hostnames: data
-      yield s.bucket.putObject("hostnames.yaml", (yaml data), "text/yaml")
+
+      if yield s.bucket.exists()
+        yield s.bucket.putObject("hostnames.yaml", (yaml data), "text/yaml")
+      else
+        console.log "WARNING: No Sky metadata detected for #{s.env}. Skipping."
 
     {fetch, add, remove: _remove}
 

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -33,12 +33,12 @@ call ->
 
   program
     .command('init')
-    .description('Initiallize a Panda Sky project.')
+    .description('Initialize a Panda Sky project.')
     .action(-> run "init")
 
   program
     .command('publish [env]')
-    .description('deploy API, Lambdas to AWS infrastructure')
+    .description('Deploy API, Lambdas to AWS infrastructure')
     .option '-o, --output [output]', 'Path to write API config file'
     .action (env, options) ->
       return if noEnv env
@@ -46,14 +46,14 @@ call ->
 
   program
     .command('delete [env]')
-    .description('deploy API, Lambdas to AWS infrastructure')
+    .description('Delete API, Lambdas from AWS infrastructure')
     .action (env) ->
       return if noEnv env
       run "delete", [env]
 
   program
     .command('render [env]')
-    .description('render the CloudFormation template to STDOUT')
+    .description('Render the CloudFormation template to STDERR')
     .action (env) ->
       return if noEnv env
       render(env)

--- a/src/commands/help.coffee
+++ b/src/commands/help.coffee
@@ -12,11 +12,11 @@ module.exports = """
 
   Commands:
 
-    build                       compile the API, Lambdas, and resources to prepare for publishing.
-    init                        Initiallize a Panda Sky project.
-    publish [options] [env]     deploy API, Lambdas to AWS infrastructure
-    delete [env]                deploy API, Lambdas to AWS infrastructure
-    render [env]                render the CloudFormation template to STDOUT
+    build                       Compile the API, Lambdas, and resources to prepare for publishing.
+    init                        Initialize a Panda Sky project.
+    publish [options] [env]     Deploy API, Lambdas to AWS infrastructure
+    delete [env]                Delete API, Lambdas from AWS infrastructure
+    render [env]                Render the CloudFormation template to STDERR
     update [env]                Update *only* the Lambda code for an environment
     domain [subcommand] [env]   Manage your API's custom domain and edge cache.
       - domain publish [env]      Upserts a CloudFront distribution for your API


### PR DESCRIPTION
In the case of domain deletion, Sky doesn't require the developer have a Sky deployment in place.  That means that attempts to update the metadata in the Sky Bucket to reflect the removal of a hostname would fail.  Now, that is allowed to happen gracefully, with a warning to the developer that Sky was not able to detect the deployment metadata.