### PR TITLE
New Features: Code Pipeline Upgrade &  Duration Timers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1904,6 +1904,16 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "moment": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
+    },
+    "moment-duration-format": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz",
+      "integrity": "sha1-VBdxtfh6BJzGVUBHXTrZZnN9aQg="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Quickly publish serverless applications in the cloud.",
   "main": "./index.js",
   "bin": {
@@ -42,6 +42,8 @@
     "jsck": "0.3.1",
     "key-forge": "1.0.0-beta-01",
     "mime": "1.5.0",
+    "moment": "^2.19.3",
+    "moment-duration-format": "^1.3.0",
     "panda-9000": "3.0.0-alpha-02",
     "panda-serialize": "0.2.0",
     "panda-template": "0.4.1",

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -7,11 +7,15 @@ require "./index"
 
 {bellChar} = require "./utils"
 help = require "./commands/help"
+init = require "./commands/init"
 render = require "./commands/render"
 build = require "./commands/build"
 publish = require "./commands/publish"
+destroy = require "./commands/delete"
+update = require "./commands/update"
 domain = require "./commands/domain"
 
+START = new Date().getTime()
 call ->
 
   noEnv = (env) ->
@@ -28,52 +32,46 @@ call ->
     .version(version)
 
   program
-    .command('build')
-    .description('compile the API, Lambdas, and resources to prepare for publishing.')
-    .action (options) -> build()
+    .command "build"
+    .action (options) -> build START
 
   program
-    .command('init')
-    .description('Initialize a Panda Sky project.')
-    .action(-> run "init")
+    .command "init"
+    .action -> init START
 
   program
-    .command('publish [env]')
-    .description('Deploy API, Lambdas to AWS infrastructure')
+    .command "publish [env]"
     .option '-o, --output [output]', 'Path to write API config file'
     .action (env, options) ->
       return if noEnv env
-      publish env, options
+      publish START, env, options
 
   program
-    .command('delete [env]')
-    .description('Delete API, Lambdas from AWS infrastructure')
+    .command "delete [env]"
     .action (env) ->
       return if noEnv env
-      run "delete", [env]
+      destroy START, env
 
   program
-    .command('render [env]')
-    .description('Render the CloudFormation template to STDERR')
+    .command "render [env]"
     .action (env) ->
       return if noEnv env
-      render(env)
+      render env
 
   program
-  .command('update [env]')
-  .description('Update *only* the Lambda code for an environment')
+  .command "update [env]"
   .action (env) ->
     return if noEnv env
-    run "update", [env]
+    update START, env
 
   program
-  .command('domain [subcommand] [env]')
+  .command "domain [subcommand] [env]"
   .option '--hard', 'In domain publish, use hard rollover for replacements.'
   .option '--yes', "Always answer warning prompts with yes. Use with caution."
   .action (subcommand, env, options) ->
     if domain[subcommand]
       return if noEnv env
-      domain[subcommand] env, options
+      domain[subcommand] START, env, options
     else
       console.error "ERROR: unrecognized subcommand of sky domain."
       program.help()

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -8,6 +8,7 @@ require "./index"
 {bellChar} = require "./utils"
 help = require "./commands/help"
 render = require "./commands/render"
+build = require "./commands/build"
 publish = require "./commands/publish"
 domain = require "./commands/domain"
 
@@ -29,7 +30,7 @@ call ->
   program
     .command('build')
     .description('compile the API, Lambdas, and resources to prepare for publishing.')
-    .action((options) -> run "build")
+    .action (options) -> build()
 
   program
     .command('init')

--- a/src/commands/build.coffee
+++ b/src/commands/build.coffee
@@ -5,12 +5,16 @@ path = require "path"
 rmrf = lift require "rimraf"
 
 {render} = Asset = require "../asset"
-{safe_mkdir} = require "../utils"
+{safe_mkdir, bellChar, outputDuration} = require "../utils"
 
-module.exports = async ->
+START = 0
+module.exports = async (start) ->
+  START = start
   if yield exists ".babelrc"
+    console.error ".babelrc file detected.  Disabling default asset pipeline."
     run "custom-build"
   else
+    console.error "Preparing code..."
     run "build"
 
 define "build", ["survey"], async -> yield build()
@@ -53,5 +57,7 @@ build = async ->
     yield safe_mkdir "deploy"
     yield shell "zip -qr deploy/package.zip lib"
 
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error e.stack
+  console.error bellChar

--- a/src/commands/build.coffee
+++ b/src/commands/build.coffee
@@ -1,13 +1,22 @@
 {writeFileSync} = require "fs"
 path = require "path"
 {go, tee, pull, values, async, lift, shell, exists} = require "fairmont"
-{define, write} = require "panda-9000"
+{define, write, run} = require "panda-9000"
 rmrf = lift require "rimraf"
 
 {render} = Asset = require "../asset"
 {safe_mkdir} = require "../utils"
 
-define "build", ["survey"], async ->
+module.exports = async ->
+  if yield exists ".babelrc"
+    run "custom-build"
+  else
+    run "build"
+
+define "build", ["survey"], async -> yield build()
+define "custom-build", ["custom-survey"], async -> yield build()
+
+build = async ->
   try
     source = "src"
     target = "lib"

--- a/src/commands/delete.coffee
+++ b/src/commands/delete.coffee
@@ -1,8 +1,13 @@
-{define} = require "panda-9000"
+{define, run} = require "panda-9000"
 {async, first, sleep} = require "fairmont"
 
-{bellChar} = require "../utils"
+{bellChar, outputDuration} = require "../utils"
 configuration = require "../configuration"
+
+START = 0
+module.exports = (start, env) ->
+  START = start
+  run "delete", [env]
 
 define "delete", async (env) ->
   try
@@ -19,7 +24,7 @@ define "delete", async (env) ->
       console.error "WARNING: No Sky stack detected. Now checking for metadata."
 
     yield sky.stack.postDelete()
-    console.error "Done.\n\n"
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error e.stack
   console.error bellChar

--- a/src/commands/domain/delete.coffee
+++ b/src/commands/domain/delete.coffee
@@ -1,9 +1,9 @@
 {async} = require "fairmont"
 
-{bellChar} = require "../../utils"
+{bellChar, outputDuration} = require "../../utils"
 configuration = require "../../configuration"
 
-module.exports = async (env, options) ->
+module.exports = async (START, env, options) ->
   try
     appRoot = process.cwd()
     console.error "Compiling configuration for API custom domain."
@@ -13,7 +13,7 @@ module.exports = async (env, options) ->
     yield sky.domain.preDelete config.aws.hostnames[0], options
     console.error "\nDeleting..."
     yield sky.domain.delete config.aws.hostnames[0]
-    console.error "Done.\n\n"
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error "Delete failure:"
     console.error e.stack

--- a/src/commands/domain/invalidate.coffee
+++ b/src/commands/domain/invalidate.coffee
@@ -1,9 +1,9 @@
 {async} = require "fairmont"
 
-{bellChar} = require "../../utils"
+{bellChar, outputDuration} = require "../../utils"
 configuration = require "../../configuration"
 
-module.exports = async (env, options) ->
+module.exports = async (START, env, options) ->
   try
     appRoot = process.cwd()
     console.error "Compiling configuration for API custom domain."
@@ -12,7 +12,7 @@ module.exports = async (env, options) ->
 
     yield sky.domain.preInvalidate config.aws.hostnames[0], options
     yield sky.domain.invalidate config.aws.hostnames[0]
-    console.error "Done.\n\n"
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error "Invalidation failure:"
     console.error e.stack

--- a/src/commands/domain/publish.coffee
+++ b/src/commands/domain/publish.coffee
@@ -1,9 +1,9 @@
 {async} = require "fairmont"
 
-{bellChar} = require "../../utils"
+{bellChar, outputDuration} = require "../../utils"
 configuration = require "../../configuration"
 
-module.exports = async (env, options) ->
+module.exports = async (START, env, options) ->
   try
     appRoot = process.cwd()
     console.error "Compiling configuration for API custom domain."
@@ -11,7 +11,7 @@ module.exports = async (env, options) ->
     sky = yield require("../../aws/sky")(env, config)
 
     yield sky.domain.prePublish config.aws.hostnames[0], options
-    console.error "Done.\n\n"
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error "Publish failure:"
     console.error e.stack

--- a/src/commands/init.coffee
+++ b/src/commands/init.coffee
@@ -1,11 +1,17 @@
 {join} = require "path"
-{define} = require "panda-9000"
-{async, randomWords, read, write, shell} = require "fairmont"
+{define, run} = require "panda-9000"
+{async, randomWords, read, write, shell, exists} = require "fairmont"
 PandaTemplate = require("panda-template").default
-{safe_cp, safe_mkdir} = require "../utils"
+{safe_cp, safe_mkdir, bellChar, outputDuration} = require "../utils"
 interview = require "../interview"
 
 # This sets up an existing directory to hold a Panda Sky project.
+START = 0
+module.exports = (start) ->
+  START = start
+  run "init"
+
+
 define "init", async ->
   try
     # Ask politely to install fairmont and js-yaml
@@ -39,6 +45,9 @@ define "init", async ->
 
     T = new PandaTemplate()
     render = async (src, target) ->
+      if yield exists target
+        console.error "Warning: #{target} exists. Skipping."
+        return
       template = yield read src
       output = T.render template, config
       yield write target, output
@@ -53,5 +62,7 @@ define "init", async ->
     yield safe_cp (src "api"), (target "src/")
 
     console.error "Panda Sky project initialized."
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error e.stack
+  console.error bellChar

--- a/src/commands/publish.coffee
+++ b/src/commands/publish.coffee
@@ -2,10 +2,10 @@
 {yaml} = require "panda-serialize"
 
 
-{bellChar} = require "../utils"
+{bellChar, outputDuration} = require "../utils"
 configuration = require "../configuration"
 
-module.exports = async (env, options) ->
+module.exports = async (START, env, options) ->
   try
     appRoot = process.cwd()
     console.error "Compiling configuration for publish"
@@ -17,7 +17,7 @@ module.exports = async (env, options) ->
     yield sky.cfo.publishWait() if isPublishing
     yield sky.stack.postPublish()
     yield writeOutput sky if options.output
-    console.error "Done.\n\n"
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error "Publish failure:"
     console.error e.stack

--- a/src/commands/survey-custom/index.coffee
+++ b/src/commands/survey-custom/index.coffee
@@ -1,0 +1,42 @@
+{async, go, map, tee, reject, read,
+w, include, Type, isType, Method,
+glob} = require "fairmont"
+
+{join} = require "path"
+{define, context} = require "panda-9000"
+babel = require "babel-core"
+
+{save, render} = Asset = require "../../asset"
+
+type = Type.define Asset
+
+define "custom-survey", ->
+  try
+    source = "src"
+    go [
+      glob "**/*", source
+      map context source
+      tee ({source, target}) -> target.extension = source.extension
+      map (context) -> include (Type.create type), context
+      tee save
+    ]
+  catch e
+    console.error e.stack
+    process.exit()
+
+
+Method.define render, (isType type), async ({source, target}) ->
+  # AWS Lambda runtimes only go up to Node v6.10.  Babel allows us to support more advanced JavaScript, like the ES6 standard.
+  try
+    source.content ?= yield read source.path
+
+    env = join __dirname, "..", "..", "..", "node_modules", "babel-preset-env"
+    {code} = babel.transform source.content,
+      sourceFileName: source.name + source.extension
+      extends: join process.cwd(), ".babelrc"
+
+    target.content = code
+  catch e
+    console.error "Transpilation failure for #{source.path}"
+    console.error e
+    process.exit -1

--- a/src/commands/survey/index.coffee
+++ b/src/commands/survey/index.coffee
@@ -1,2 +1,3 @@
 require "./pass-thru"
 require "./coffee"
+require "./javascript"

--- a/src/commands/survey/pass-thru.coffee
+++ b/src/commands/survey/pass-thru.coffee
@@ -7,7 +7,7 @@ glob} = require "fairmont"
 {save, render} = Asset = require "../../asset"
 {pathWithUnderscore} = require "../../utils"
 
-formats = w ".html .css .js .xml .json .yaml"
+formats = w ".html .css .xml .json .yaml"
 
 type = Type.define Asset
 

--- a/src/commands/update.coffee
+++ b/src/commands/update.coffee
@@ -1,11 +1,17 @@
 {join} = require "path"
-{define, write} = require "panda-9000"
+{define, write, run} = require "panda-9000"
 {yaml} = require "panda-serialize"
 {async, go, tee, pull, values, shell, exists} = require "fairmont"
 
-{bellChar} = require "../utils"
+{bellChar, outputDuration} = require "../utils"
 configuration = require "../configuration"
 {render} = Asset = require "../asset"
+
+START = 0
+module.exports = (start, env) ->
+  START = start
+  console.error "Updating #{env}..."
+  run "update", [env]
 
 define "update", ["survey"], async (env) ->
   try
@@ -37,7 +43,7 @@ define "update", ["survey"], async (env) ->
 
     # Update Sky metadata with new Zip acrhive, and republish all lambdas.
     yield sky.lambdas.update()
-
+    console.error "Done. (#{outputDuration START})\n\n"
   catch e
     console.error e.stack
   console.error bellChar

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,6 +3,5 @@ require "./commands/delete"
 require "./commands/init"
 require "./commands/publish"
 require "./commands/survey"
+require "./commands/survey-custom"
 require "./commands/update"
-
-module.exports = (AWS) -> require("./sky-helpers")(AWS)

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -1,4 +1,6 @@
 {async, isMatch, shell, exists, mkdir, isDirectory} = require "fairmont"
+moment = require "moment"
+require "moment-duration-format"
 
 module.exports =
 
@@ -25,3 +27,12 @@ module.exports =
       yield shell "cp #{original} #{target}"
 
   bellChar: '\u0007'
+
+  outputDuration: (start) ->
+    d = moment.duration(new Date().getTime() - start)
+    if 0 < d.asSeconds() <= 60
+      d.format("s[ s]", 1)
+    else if 60 < d.asSeconds() < 3600
+      d.format("m:ss[ min]", 0)
+    else
+      d.format("h:mm[ hr]", 0)


### PR DESCRIPTION
There are a couple features in this upgrade.
- CoffeeScript pipeline: now has source mapping.  When used with panda-sky-helpers, you get proper stack traces in Lambda.
- Javascript: now has a general pipeline targeting Node 6.10 compatibility.  Also has source mapping.
- Added durations to most CLI commands
- Corrected bug where `sky init` was destructively adding `sky.yaml` files.  😨 

I'm giving this a minor version bump to `v2.3.0`