### PR TITLE
Sky v2.5 Log Tailing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -829,6 +829,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bartlett": {
+      "version": "1.0.0-alpha-02",
+      "resolved": "https://registry.npmjs.org/bartlett/-/bartlett-1.0.0-alpha-02.tgz",
+      "integrity": "sha1-x6CaIQTCG3iJ+eOB3n+TxwjMqsE="
     },
     "base64-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-sky",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Quickly publish serverless applications in the cloud.",
   "main": "./index.js",
   "bin": {
@@ -34,7 +34,9 @@
     "aws-sdk": "2.156.0",
     "babel-core": "6.26.0",
     "babel-preset-env": "1.6.1",
+    "bartlett": "^1.0.0-alpha-02",
     "coffeescript": "2.1.0",
+    "colors": "^1.1.2",
     "commander": "2.12.0",
     "fairmont": "2.0.1",
     "handlebars": "4.0.11",

--- a/src/aws/index.coffee
+++ b/src/aws/index.coffee
@@ -42,7 +42,8 @@ module.exports = async (region) ->
   cfo = liftModule new AWS.CloudFormation()
   cfr = liftModule new AWS.CloudFront()
   lambda = liftModule new AWS.Lambda()
+  logs = liftModule new AWS.CloudWatchLogs()
   route53 = liftModule new AWS.Route53()
   s3 = liftModule new AWS.S3()
 
-  {AWS, acm, agw, gw, cfo, cfr, lambda, route53, s3}
+  {AWS, acm, agw, gw, cfo, cfr, lambda, logs, route53, s3}

--- a/src/aws/logs.coffee
+++ b/src/aws/logs.coffee
@@ -1,0 +1,48 @@
+{async, cat, empty} = require "fairmont"
+
+
+module.exports = async (env, config) ->
+  {logs} = yield require("./index")(config.aws.region)
+
+  # Returns data on a group or groups given an input prefix.
+  listGroups = async (prefix, current=[], token) ->
+    params = logGroupNamePrefix: prefix
+    params.nextToken = token if token
+    {logGroups, nextToken} = yield logs.describeLogGroups params
+    current = cat current, logGroups
+    if nextToken
+      yield listGroups prefix, current, nextToken
+    else
+      current
+
+  getNewestStream = async (name) ->
+    params =
+      logGroupName: name
+      orderBy: "LastEventTime"
+      descending: true
+      limit: 1
+
+    {logStreams} = yield logs.describeLogStreams params
+    if empty logStreams
+      undefined
+    else
+      logStreams[0]
+
+  tailEvents = async (group, stream, time, current=[], token=false) ->
+    params =
+      logGroupName: group
+      logStreamName: stream
+      startTime: time
+      startFromHead: true
+    params.nextToken = token if token
+
+    {events, nextForwardToken} = yield logs.getLogEvents params
+    current = cat current, events
+    if nextForwardToken != token
+      yield tailEvents group, stream, time, current, nextForwardToken
+    else
+      current
+
+
+  # Return exposed functions.
+  {listGroups, getNewestStream, tailEvents}

--- a/src/aws/sky/index.coffee
+++ b/src/aws/sky/index.coffee
@@ -29,6 +29,7 @@ module.exports = async (env, config) ->
   s.bucket = yield require("../s3")(env, config, s.srcName)
   s.lambda = yield require("../lambda")(config)
   s.route53 = yield require("../route53")(s)
+  s.logs = yield require("../logs")(env, config)
 
   # Stack sub-resources
   s.domain = domain s

--- a/src/aws/sky/lambdas.coffee
+++ b/src/aws/sky/lambdas.coffee
@@ -1,7 +1,87 @@
-{async, read, toLower} = require "fairmont"
+{async, read, toLower, cat, empty, collect, compact, project, sleep, last, md5, rest, first} = require "fairmont"
 {yaml} = require "panda-serialize"
 
 module.exports = (s) ->
+  # Get names of all Lambdas
+  list = async ->
+    api = yaml yield read s.apiDef
+    names =
+      for r, resource of api.resources
+        for m, method of resource.methods
+          "#{s.stackName}-#{r}-#{toLower m}"
+    cat names...
+
+  fail = ->
+    console.error """
+    WARNING: No Sky metadata detected for this deployment.  This feature is
+    meant only for pre-existing Sky deployments and will not continue.
+
+    Done.
+    """
+    process.exit()
+
+  # This lays out one scan cycle.
+  scanLogs = async (timeKey) ->
+    # Get any CloudWatch log group belonging to this deployment.
+    groups = yield s.logs.listGroups "/aws/lambda/#{s.stackName}"
+    return [] if empty groups
+
+    # Get the most recent log streams in each group.
+    streams =
+      for g in groups
+        stream = yield s.logs.getNewestStream g.logGroupName
+        stream.group = g.logGroupName if stream
+        stream
+    streams = collect compact streams
+    return [] if empty streams
+
+    # Get the most recent log events for each stream.
+    events =
+      for stream in streams
+        {group, logStreamName: name} = stream
+        yield s.logs.tailEvents group, name, timeKey
+
+    # Output a flat array, timesorted.
+    cat(events...).sort (a, b) -> a.timestamp - b.timestamp
+
+
+  # Seamlessly stitch together the events that were just fetched with the ones that are already written to the screen.
+  reconcileEvents = (events, time, event) ->
+    return events if !time && !event
+    while true
+      return [] if empty events
+      e = first events
+      if e.timestamp == time && md5(e.message) == event
+        return rest events
+      else
+        events = rest events
+
+
+  outputLogs = (events) ->
+    console.error e.timestamp, e.message for e in events
+
+  # Tail the logs output by the various Lambdas.
+  tail = async ->
+      fail() if !yield s.meta.current.fetch()
+      time = new Date().getTime()
+      latestTime = false
+      latestEvent = false
+
+      while true
+        events = yield scanLogs time
+        if !empty events
+          events = reconcileEvents events, latestTime, latestEvent
+
+        if !empty events
+          lastEvent = last events
+          latestTime = lastEvent.timestamp
+          latestEvent = md5 lastEvent.message
+          outputLogs events
+          time = latestTime - 1
+
+        yield sleep 2000
+
+
   update = async ->
     fail() if !yield s.meta.current.fetch()
     names = yield list()
@@ -11,22 +91,4 @@ module.exports = (s) ->
     yield s.meta.handlers.update()
     yield Promise.all republish()
 
-  # Get names of all Lambdas
-  list = async ->
-    api = yaml yield read s.apiDef
-    lambdas = []
-    for r, resource of api.resources
-      for m, method of resource.methods
-        lambdas.push "#{s.stackName}-#{r}-#{toLower m}"
-    lambdas
-
-  fail = ->
-    console.error """
-    WARNING: No Sky metadata detected for this deployment.  'sky update' is
-    meant only for pre-existing Sky deployments and will not continue.
-
-    Done.
-    """
-    process.exit()
-
-  {update}
+  {tail, update}

--- a/src/aws/sky/lambdas/index.coffee
+++ b/src/aws/sky/lambdas/index.coffee
@@ -1,0 +1,8 @@
+update = require "./update"
+tail = require "./tail"
+
+module.exports = (s) ->
+  {
+    tail: tail s
+    update: update s
+  }

--- a/src/aws/sky/lambdas/logs/parse.coffee
+++ b/src/aws/sky/lambdas/logs/parse.coffee
@@ -1,0 +1,64 @@
+{regexp, many, any, all, rule, grammar} = require "bartlett"
+{merge} = require "fairmont"
+require "colors"
+
+validTypes = ["ERROR", "WARN", "INFO", "DEBUG", "START", "END", "REPORT"]
+
+# Temp fix for bug in Bartlett.  TODO: Make this change in Bartlett.
+regexp = (re) ->
+  (s) ->
+    if (match = s.match(re))?
+      [value] = match
+      rest = s[value.length..]
+      {value, rest}
+
+validate = (p, f) ->
+  (s) ->
+    result = p(s)
+    if result && f result then result else null
+
+finish = (f) ->
+  (s) ->
+    result = f(s)
+    result.rest = '' if result
+    result
+
+# General helpers parsers to identify message type and when everything ends.
+_type = rule (regexp /^[A-Z]+/), ({value}) -> Type: value
+type = validate _type, ({value: {Type}}) -> Type in validTypes
+eol = regexp /^\n$/
+
+# Parsers for system messages from Lambdas: START, END, REPORT
+name = regexp /^[\w\s]+/
+delimiter = regexp /^\:/
+value  = rule (regexp /^\s?[^\s]*\s/), ({value}) -> value.trim()
+tabbedValue = rule (regexp /^\s?[^\t]*(\t|\n$)/), ({value}) -> value.trim()
+
+field = (valueRule) ->
+  rule (all name, delimiter, valueRule),
+    ({value: [name, , value]}) -> [name.trim()]: value.trim()
+fields = (fieldRule) ->
+  rule (many fieldRule), ({value}) -> merge value...
+
+report = rule (all type, (fields (field tabbedValue)), eol),
+  ({value: [type, fields]}) -> merge type, fields
+
+simple = rule (all type, (fields (field value))),
+  ({value: [type, fields]}) -> merge type, fields
+
+# Parsers for the explicit console messages, written manually by developers.
+namedLevel = finish rule type,
+  ({value: {Type}, rest}) -> {Type, Message: rest.trim()}
+noLevel = (s) -> value: { Type: "CONSOLE", Message: s.trim()}, rest: ''
+message = any namedLevel, noLevel
+manual = rule (all tabbedValue, tabbedValue, message),
+  ({value: [Timestamp, RequestId, {Type, Message}]}) ->
+    {Timestamp, RequestId, Type, Message}
+
+fallback = (s) -> value: { Type: "UKNOWN", Message: s}, rest: ''
+
+parse = grammar any report, simple, manual, fallback
+
+module.exports = ({timestamp, message}) ->
+  output = parse(message) || {}
+  merge output, Timestamp: timestamp

--- a/src/aws/sky/lambdas/logs/print.coffee
+++ b/src/aws/sky/lambdas/logs/print.coffee
@@ -1,0 +1,58 @@
+debugEquivalents = ["DEBUG", "START", "END", "REPORT"]
+
+parseTime = (d) ->
+  pad = (s) -> if s.toString().length == 1 then "0#{s}" else s
+  i = (n) -> n + 1
+  date = "#{d.getUTCFullYear()}-#{pad i d.getUTCMonth()}-#{pad d.getUTCDate()}"
+  time = "#{pad i d.getUTCHours()}:#{pad d.getUTCMinutes()}:#{pad d.getUTCSeconds()}.#{d.getUTCMilliseconds()} UTC"
+  "#{date} #{time}"
+
+justify = (final, s) -> s + " ".repeat(final - s.length)
+
+space = (one, two, three, four) ->
+  one = justify 9, one
+  if four
+    [one, two, three, four].join "  "
+  else
+    [one, two, three].join "  "
+
+# Convert the parse object into a normalized string for output or show problem.
+normalize = (parsedOutput) ->
+  {Type="UNKNOWN", RequestId, Message="", Timestamp} = parsedOutput
+  Timestamp = parseTime new Date Timestamp
+
+  switch Type
+    when "REPORT"
+      output = space "[REPORT]", "#{Timestamp}", "#{RequestId}"
+      output +="\n    Duration: #{parsedOutput.Duration}"
+      output +="\n    Max Memory Used: #{parsedOutput["Max Memory Used"]}"
+      output +="\n    Billed Duration: #{parsedOutput["Billed Duration"]}"
+      output +="\n    Memory Size: #{parsedOutput["Memory Size"]}"
+    when "UNKNOWN"
+      console.error "### Sky is unable to parse this log. Displaying raw data.".yellow
+      output = Message
+    when "START", "END"
+      output = space "[#{Type}]", "#{Timestamp}", "#{RequestId}"
+    else
+      output = space "[#{Type}]", "#{Timestamp}", "#{RequestId}", "#{Message}"
+
+  # Return the formmatted strings with their appropriate colors.
+  switch Type
+    when "INFO"
+      output.green
+    when "START", "END", "REPORT", "DEBUG"
+      output.cyan
+    when "WARN"
+      output.yellow
+    when "ERROR"
+      output.red
+    when "CONSOLE"
+      output
+    else
+      output
+
+module.exports = (isVerbose, e) ->
+  if isVerbose
+    console.error normalize e
+  else if e.Type not in debugEquivalents
+    console.error normalize e

--- a/src/aws/sky/lambdas/tail.coffee
+++ b/src/aws/sky/lambdas/tail.coffee
@@ -46,7 +46,6 @@ module.exports = (s) ->
 
   # Tail the logs output by the various Lambdas.
   async (isVerbose) ->
-      fail() if !yield s.meta.current.fetch()
       time = new Date().getTime()
       latestTime = false
       latestEvent = false

--- a/src/aws/sky/lambdas/update.coffee
+++ b/src/aws/sky/lambdas/update.coffee
@@ -1,0 +1,30 @@
+{async, read, toLower, cat, empty, collect, compact, project, sleep, last, md5, rest, first} = require "fairmont"
+{yaml} = require "panda-serialize"
+
+module.exports = (s) ->
+  # Get names of all Lambdas
+  list = async ->
+    api = yaml yield read s.apiDef
+    names =
+      for r, resource of api.resources
+        for m, method of resource.methods
+          "#{s.stackName}-#{r}-#{toLower m}"
+    cat names...
+
+  fail = ->
+    console.error """
+    WARNING: No Sky metadata detected for this deployment.  This feature is
+    meant only for pre-existing Sky deployments and will not continue.
+
+    Done.
+    """
+    process.exit()
+
+  async ->
+    fail() if !yield s.meta.current.fetch()
+    names = yield list()
+    republish = ->
+      s.lambda.update(name, s.srcName, "package.zip") for name in names
+
+    yield s.meta.handlers.update()
+    yield Promise.all republish()

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -58,6 +58,12 @@ call ->
     COMMANDS.update START, env
 
   program
+    .command "tail [env]"
+    .action (env, others) ->
+      return if noEnv env
+      COMMANDS.tail env
+
+  program
   .command "domain [subcommand] [env]"
   .option '--hard', 'In domain publish, use hard rollover for replacements.'
   .option '--yes', "Always answer warning prompts with yes. Use with caution."

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -59,9 +59,10 @@ call ->
 
   program
     .command "tail [env]"
-    .action (env, others) ->
+    .option '-v, --verbose', 'output debug level logs'
+    .action (env, options) ->
       return if noEnv env
-      COMMANDS.tail env
+      COMMANDS.tail env, options
 
   program
   .command "domain [subcommand] [env]"

--- a/src/commands/help.coffee
+++ b/src/commands/help.coffee
@@ -14,6 +14,8 @@ module.exports = """
     init                        Initialize a Panda Sky project.
     publish [options] [env]     Deploy API, Lambdas to AWS infrastructure
     delete [env]                Delete API, Lambdas from AWS infrastructure
+    tail   [env]                Tail the logs for the given environment
+      [-v, --verbose]               Output debug level logs
     render [env]                Render the CloudFormation template to STDERR
     update [env]                Update *only* the Lambda code for an environment
     domain [subcommand] [env]   Manage your API's custom domain and edge cache.

--- a/src/commands/index.coffee
+++ b/src/commands/index.coffee
@@ -6,6 +6,7 @@ init = require "./init"
 mixin = require "./mixin"
 publish = require "./publish"
 render = require "./render"
+tail = require "./tail"
 update = require "./update"
 
 
@@ -19,5 +20,6 @@ module.exports = {
   mixin
   publish
   render
+  tail
   update
 }

--- a/src/commands/tail.coffee
+++ b/src/commands/tail.coffee
@@ -1,0 +1,18 @@
+{async, write} = require "fairmont"
+
+{bellChar, outputDuration} = require "../utils"
+configuration = require "../configuration"
+
+module.exports = async (env) ->
+  try
+    appRoot = process.cwd()
+    console.error "Preparing task."
+    config = yield configuration.compile(appRoot, env)
+    sky = yield require("../aws/sky")(env, config)
+
+    console.error "Tailing Sky API logs... (Press ^C at any time to quit.)"
+    console.error "=".repeat 80
+    yield sky.lambdas.tail()
+  catch e
+    console.error "Log tailing failure:"
+    console.error e.stack

--- a/src/commands/tail.coffee
+++ b/src/commands/tail.coffee
@@ -3,7 +3,7 @@
 {bellChar, outputDuration} = require "../utils"
 configuration = require "../configuration"
 
-module.exports = async (env) ->
+module.exports = async (env, {verbose}) ->
   try
     appRoot = process.cwd()
     console.error "Preparing task."
@@ -12,7 +12,7 @@ module.exports = async (env) ->
 
     console.error "Tailing Sky API logs... (Press ^C at any time to quit.)"
     console.error "=".repeat 80
-    yield sky.lambdas.tail()
+    yield sky.lambdas.tail(verbose)
   catch e
     console.error "Log tailing failure:"
     console.error e.stack


### PR DESCRIPTION
This adds the ability to tail logs from a given deployment with the command:

```
$ sky tail [environment] [-v]
```
Sky gathers all the CloudWatch logs, parses them, and places them in developer's terminal.  Even includes color coding!!